### PR TITLE
Revert "Fix#5 api2.1.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.brandeis.cs.lapps</groupId>
     <artifactId>stanfordnlp-web-service</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Web Services wrapping Stanford  CoreNLP tools</name>
     <description>
@@ -81,6 +81,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.lappsgrid</groupId>
+            <artifactId>discriminator</artifactId>
+            <version>2.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
             <version>${stanford.version}</version>
@@ -100,7 +105,7 @@
         <dependency>
             <groupId>org.lappsgrid</groupId>
             <artifactId>all</artifactId>
-            <version>2.1.1</version>
+            <version>2.0.4</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/edu/brandeis/cs/lappsgrid/stanford/corenlp/POSTagger.java
+++ b/src/main/java/edu/brandeis/cs/lappsgrid/stanford/corenlp/POSTagger.java
@@ -2,7 +2,6 @@ package edu.brandeis.cs.lappsgrid.stanford.corenlp;
 
 import edu.brandeis.cs.lappsgrid.stanford.StanfordWebServiceException;
 import edu.brandeis.cs.lappsgrid.stanford.corenlp.api.IPOSTagger;
-import edu.stanford.nlp.ling.CoreAnnotation;
 import edu.stanford.nlp.ling.CoreAnnotations.PartOfSpeechAnnotation;
 import edu.stanford.nlp.ling.CoreAnnotations.SentencesAnnotation;
 import edu.stanford.nlp.ling.CoreAnnotations.TokensAnnotation;
@@ -49,7 +48,8 @@ public class POSTagger extends AbstractStanfordCoreNLPWebService implements
                 Annotation a = newAnnotation(view,
                         String.format("%s%d_%d", TOKEN_ID, sid, tid++), Uri.POS,
                         token.beginPosition(), token.endPosition());
-                a.addFeature(Features.Token.POS, token.get(PartOfSpeechAnnotation.class));
+                a.addFeature(Features.Token.PART_OF_SPEECH, token.get(PartOfSpeechAnnotation.class));
+                a.addFeature(Features.Token.WORD, token.value());
             }
         }
 


### PR DESCRIPTION
Reverts brandeis-nlp/edu.brandeis.cs.stanfordnlp-web-service#6 to keep v2.0.0 separately. 
